### PR TITLE
Temporary fix for Firefox

### DIFF
--- a/app/Daemon.hs
+++ b/app/Daemon.hs
@@ -31,7 +31,6 @@ import Data.Int (Int32)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Text (Text)
-import qualified Data.Text as Text
 import Data.Word (Word32)
 import Network.Socket (
   Family (AF_UNIX),
@@ -172,10 +171,10 @@ notifyDefault state appName replaceId appIcon summary body actions hints _ = do
           , nTimeout = cfg // settings // timeout // byUrgency // currentUrgency
           , nTimestamp = timestamp
           , notifyType = Nothing
-          , appName = Text.replace "\n" " " appName
+          , appName = appName
           , appIcon = appIcon
-          , summary = Text.replace "\n" " " summary
-          , body = Text.replace "\n" " " body
+          , summary = summary
+          , body = body
           , hintString = hintString
           , widget = cfg // settings // ewwDefaultNotificationKey
           }
@@ -255,7 +254,8 @@ displayNotifications :: Maybe EwwWindow -> [Notification] -> IO ()
 displayNotifications w l =
   if not $ null l
     then do
-      let widgetString = buildWidgetWrapper True $ buildWidgetString l
+      let replaceNewlines = map (\c -> if c=='\n' then ' '; else c)
+      let widgetString = replaceNewlines (buildWidgetWrapper True $ buildWidgetString l)
       putStrLn widgetString
       callCommand $ setEwwValue "end-notifications" widgetString
       mapM_ openEwwWindow w

--- a/app/Daemon.hs
+++ b/app/Daemon.hs
@@ -254,8 +254,7 @@ displayNotifications :: Maybe EwwWindow -> [Notification] -> IO ()
 displayNotifications w l =
   if not $ null l
     then do
-      let replaceNewlines = map (\c -> if c=='\n' then ' '; else c)
-      let widgetString = replaceNewlines (buildWidgetWrapper True $ buildWidgetString l)
+      let widgetString = buildWidgetWrapper True $ replaceNewlines $ buildWidgetString l
       putStrLn widgetString
       callCommand $ setEwwValue "end-notifications" widgetString
       mapM_ openEwwWindow w

--- a/app/Util/Helpers.hs
+++ b/app/Util/Helpers.hs
@@ -23,9 +23,13 @@ flip23 f a c b = f a b c
 tuple :: a -> (a, a)
 tuple v = (v, v)
 
+replaceNewlines :: String -> String
+replaceNewlines = map (\c -> if c == '\n' then ' ' else c)
+
 replaceOrPrepend :: (a -> Bool) -> a -> [a] -> [a]
 replaceOrPrepend f e l = if fst replaceResult then snd replaceResult else e : l
-  where replaceResult = tryReplace f e l
+ where
+  replaceResult = tryReplace f e l
 
 -- Tries to replace the first element that matches the predicate.
 -- Returns (True, l) where l is the new list if an element was replaced
@@ -34,5 +38,5 @@ tryReplace :: (a -> Bool) -> a -> [a] -> (Bool, [a])
 tryReplace f e [] = (False, [])
 tryReplace f e (h : l) = if f h then (True, e : l) else second (h :) (tryReplace f e l)
 
-minWith :: Ord b => (a -> b) -> [a] -> a
+minWith :: (Ord b) => (a -> b) -> [a] -> a
 minWith f = minimumBy (\a b -> compare (f a) (f b))


### PR DESCRIPTION
Apologizes about the code, I've never written Haskell.

This gets Firefox to use our notification server, instead of it's own popups. `Map.delete "image-data" hints` is a temporary fix because this hint contains the raw image data, which eww doesn't like (I think). Really, we need to write this image-data to a temporary file, then give that file path to eww, and finally delete the file when the notification is closed. But that sounds extremely annoying.